### PR TITLE
Небольшие изменения

### DIFF
--- a/src/components/external_link.tsx
+++ b/src/components/external_link.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@mui/material'
 import { useEffect, useState } from 'react'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { grey } from '@mui/material/colors'
 
 interface ExternalLinkInfo {
   link: string
@@ -56,13 +57,20 @@ export const ExternalLink = () => {
     }
   }, [])
 
+  const color = grey[900]
+
   return (
     <span>
       <Link
         href={`${info?.link}?access_token=${auth.access_token}&refresh_token=${auth.refresh_token}`}
-        target="_blank"
         rel="noreferrer"
-        sx={{ display: 'flex', flexDirection: 'row' }}
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          color,
+        }}
+        variant="subtitle2"
+        underline="none"
       >
         {info?.description}
         <OpenInNewIcon />

--- a/src/fields/DepartmentField.tsx
+++ b/src/fields/DepartmentField.tsx
@@ -27,7 +27,7 @@ const DepartmentField = () => {
           <MenuItem key={department.id} value={JSON.stringify(department)}>
             <ListItemText>{department.name}</ListItemText>
             <Typography variant="body2" color="text.secondary">
-              {department.description}
+              {department.hospital.name || ''} {department.description}
             </Typography>
           </MenuItem>
         ))}

--- a/src/modules/User/UsersList.tsx
+++ b/src/modules/User/UsersList.tsx
@@ -144,12 +144,22 @@ const UsersList: React.FC = () => {
                         {row.gender}
                       </TableCell>
                       <TableCell component="th" scope="row">
-                        <Stack direction="row" spacing={1}>
-                          {row.roles.map((role) => (
-                            <Tooltip key={role.id} title={role.description}>
-                              <Chip label={role.name} size="small" />
-                            </Tooltip>
-                          ))}
+                        <Stack
+                          direction="row"
+                          flexWrap={'wrap'}
+                          maxWidth={'380px'}
+                          spacing={1}
+                        >
+                          {row.roles
+                            .filter(
+                              (obj, idx, arr) =>
+                                idx === arr.findIndex((v) => v.id === obj.id)
+                            )
+                            .map((role) => (
+                              <Tooltip key={role.id} title={role.description}>
+                                <Chip label={role.name} size="small" />
+                              </Tooltip>
+                            ))}
                         </Stack>
                       </TableCell>
                       <TableCell component="th" scope="row">


### PR DESCRIPTION

- название physiocms на том же фоне как и имя пользователя с тем же стилем, открывать в этом же окне не в новом.
- пользователи - проблемы с масштабом, не влезают в экран, видимо из за списка ролей 
- пользователи - нужно при отображении отделения также отображать название организации.